### PR TITLE
Include js runtime file

### DIFF
--- a/src-clock/dune
+++ b/src-clock/dune
@@ -4,4 +4,5 @@
  (libraries mtime)
  (modules mtime_clock)
  (c_names mtime_clock_stubs)
+ (js_of_ocaml (javascript_files runtime.js))
  (wrapped false))


### PR DESCRIPTION
Happened to be taking this for a spin in the browser where `mtime.clock.os.1.4.0` should just work thanks to the newly added runtime files, but I think they need to be included.